### PR TITLE
Improve error handling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
     #     asset_path: ${{ matrix.binary }}
     #     asset_name: ${{ matrix.rawName }}
     #     asset_content_type: application/octet-stream
-    - name: Upload to artifacat
+    - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.rawName }}


### PR DESCRIPTION
When failing to parse an action, exit the process with an error instead of processing an uninitialized Action. In particular, if stdin closes because the parent process exits, this prevents an endless stream of EOF messages.

Also, in case of SIGINT/SIGTERM, print "Quit" to stderr instead of stdout.